### PR TITLE
Fix server path in npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack serve --mode development",
     "build": "webpack --mode production",
-    "server": "node server.js"
+    "server": "node src/server.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## Summary
- fix `npm run server` by pointing to `src/server.js`

## Testing
- `npm run server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6841cb371c10832ebe88dcb311a86aab