### PR TITLE
Set backend to port 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Este proyecto es una aplicación React con un servidor Express que gestiona cier
 3. Inicia el frontend con `npm start`.
 4. En otra terminal puedes iniciar el servidor backend con `npm run server`.
 
-El servidor responde en `http://localhost:4000` y el frontend se sirve en `http://localhost:3000` por defecto.
+El servidor responde en `http://localhost:3001` y el frontend se sirve en `http://localhost:3000` por defecto.
 
 Los datos se almacenan en `db.js.db` mediante SQLite. Existen scripts adicionales como `python migracion.py` para modificar la base de datos si es necesario.

--- a/src/server.js
+++ b/src/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const cors = require('cors');
 
 const app = express();
-const PORT = process.env.PORT || 4000;
+const PORT = process.env.PORT || 3001;
 
 app.use(express.json());
 app.use(cors());


### PR DESCRIPTION
## Summary
- configure server to listen on port 3001
- document the backend port in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d064e81c832e842255be571ef8dc