### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ Este proyecto es una aplicación React con un servidor Express que gestiona cier
 ## Instalación
 
 1. Clona el repositorio.
-2. Ejecuta `npm install` en la raíz para descargar las dependencias.
+2. Ejecuta `npm install --include=dev` en la raíz para descargar todas las dependencias, incluidas las de desarrollo.
+   Si encuentras problemas de dependencias, puedes usar `npm install --legacy-peer-deps`.
 3. Inicia el frontend con `npm start`.
+   Si las dependencias de desarrollo faltan, este comando fallará con "webpack: not found".
 4. En otra terminal puedes iniciar el servidor backend con `npm run server`.
 
 El servidor responde en `http://localhost:4000` y el frontend se sirve en `http://localhost:3000` por defecto.


### PR DESCRIPTION
## Summary
- clarify that `npm install --include=dev` is required to install dev deps
- mention `npm install --legacy-peer-deps` as an alternative
- warn that missing dev dependencies will make `npm start` fail with "webpack: not found"

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d072026c832eb51f4cbe428cfb98