### PR TITLE
Centralize API base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Este proyecto es una aplicación React con un servidor Express que gestiona cier
    Si las dependencias de desarrollo faltan, este comando fallará con "webpack: not found".
 4. En otra terminal puedes iniciar el servidor backend con `npm run server`.
 
+El código fuente usa una constante `API_BASE_URL` (definida en `src/config.js`) para
+apuntar al backend. Ajusta esa constante si tu servidor Express corre en una URL
+distinta.
+
 El servidor responde en `http://localhost:3001` y el frontend se sirve en `http://localhost:3000` por defecto.
 
 Los datos se almacenan en `db.js.db` mediante SQLite. Existen scripts adicionales como `python migracion.py` para modificar la base de datos si es necesario.

--- a/src/App.js
+++ b/src/App.js
@@ -2,19 +2,22 @@ import React, { useState, useEffect } from 'react';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import MainContent from './components/MainContent';
+import { API_BASE_URL } from './config';
 
 const colors = {
   mainBg: "#1E1E1E",
   textPrimary: "#FFFFFF"
 };
 
+
 function App() {
   const [activePage, setActivePage] = useState('Home');
   const [cierres, setCierres] = useState([]); // Estado para guardar datos de la DB
 
   // Llamada al backend para obtener los cierres (DB)
+
   useEffect(() => {
-    fetch('/api/cierres')
+    fetch(`${API_BASE_URL}/api/cierres`)
       .then((response) => {
         if (!response.ok) {
           throw new Error("Error al cargar datos de cierres");

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'http://localhost:3001';

--- a/src/pages/CierreCaja.jsx
+++ b/src/pages/CierreCaja.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Imprimir from "./imprimir";
 import { useTheme } from "@mui/material/styles";
+import { API_BASE_URL } from "../config";
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1126,7 +1127,7 @@ function CierreCaja() {
   const togglePanelCierre = async () => {
     const fechaStr = fecha.toLocaleDateString("es-CL");
     try {
-      const queryUrl = `http://localhost:3001/api/cierres/existe?fecha=${encodeURIComponent(
+      const queryUrl = `${API_BASE_URL}/api/cierres/existe?fecha=${encodeURIComponent(
         fechaStr
       )}&tienda=${encodeURIComponent(selectedTienda)}&usuario=${encodeURIComponent(
         selectedUsuario
@@ -1170,7 +1171,7 @@ function CierreCaja() {
     };
   
     try {
-      const response = await fetch("http://localhost:3001/api/cierres", {
+      const response = await fetch(`${API_BASE_URL}/api/cierres`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(exportData)
@@ -1283,7 +1284,7 @@ function CierreCaja() {
 //
 async function loadAjustesFromBackend() {
   try {
-    const response = await fetch("http://localhost:3001/localStorage");
+    const response = await fetch(`${API_BASE_URL}/localStorage`);
     if (!response.ok) {
       throw new Error(`HTTP error: ${response.status}`);
     }

--- a/src/pages/Diferencias.jsx
+++ b/src/pages/Diferencias.jsx
@@ -4,6 +4,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers';
 import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 import { 
   CheckCircle as CheckCircleIcon, 
   Warning as WarningIcon, 
@@ -487,7 +488,7 @@ function ControlCajas() {
       if (tiendaSeleccionada) params.tienda = tiendaSeleccionada;
       if (usuarioSeleccionado) params.usuario = usuarioSeleccionado;
 
-      const response = await axios.get('http://localhost:3001/api/cierres-completo', { params });
+      const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`, { params });
       const cierresData = response.data.map((cierre) => {
         let mediosPago = [];
         try {
@@ -517,7 +518,7 @@ function ControlCajas() {
   useEffect(() => {
     async function loadConfig() {
       try {
-        const response = await axios.get('http://localhost:3001/localStorage');
+        const response = await axios.get(`${API_BASE_URL}/localStorage`);
         setMotivos(response.data.motivos_error_pago || []);
         setTiendas(response.data.tiendas || []);
         setMediosPagoColumns(response.data.medios_pago || []);

--- a/src/pages/Exportar.jsx
+++ b/src/pages/Exportar.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { API_BASE_URL } from '../config';
 import {
   Box,
   Card,
@@ -95,7 +96,7 @@ const ExportarPage = () => {
     try {
       setLoading(true);
       setError(null);
-      const response = await axios.get('http://localhost:3001/api/cierres-completo');
+      const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`);
       
       if (!response.data || response.data.length === 0) {
         setError('No se encontraron datos en la base de datos');

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -34,6 +34,7 @@ import {
   Warning as WarningIcon,
   TrendingUp as TrendingUpIcon,
 } from '@mui/icons-material';
+import { API_BASE_URL } from '../config';
 
 const HomePage = () => {
   const theme = useTheme();
@@ -46,7 +47,7 @@ const HomePage = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get('http://localhost:3001/api/cierres-completo');
+        const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`);
         const data = response.data;
         setCierres(data);
         procesarDatos(data);


### PR DESCRIPTION
## Summary
- added `src/config.js` with API_BASE_URL
- use API_BASE_URL in App and pages
- document API_BASE_URL in README

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e4287180832eb690714ccc8a5926