### PR TITLE
Fix API URL conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Este proyecto es una aplicación React con un servidor Express que gestiona cier
 4. En otra terminal puedes iniciar el servidor backend con `npm run server`.
 
 El servidor responde en `http://localhost:3001` y el frontend se sirve en `http://localhost:3000` por defecto.
+Puedes personalizar la URL del backend configurando la variable de entorno `REACT_APP_API_BASE_URL` antes de iniciar el frontend.
 
 Los datos se almacenan en `db.js.db` mediante SQLite. Existen scripts adicionales como `python migracion.py` para modificar la base de datos si es necesario.

--- a/src/App.js
+++ b/src/App.js
@@ -2,13 +2,12 @@ import React, { useState, useEffect } from 'react';
 import Header from './components/Header';
 import Sidebar from './components/Sidebar';
 import MainContent from './components/MainContent';
+import { API_BASE_URL } from './config';
 
 const colors = {
   mainBg: "#1E1E1E",
   textPrimary: "#FFFFFF"
 };
-
-const API_BASE_URL = 'http://localhost:3001';
 
 function App() {
   const [activePage, setActivePage] = useState('Home');

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001';

--- a/src/pages/Ajustes.jsx
+++ b/src/pages/Ajustes.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios'; // Importa Axios para realizar peticiones HTTP
+import { API_BASE_URL } from '../config';
 import { keyframes } from '@emotion/react';
 
 // Datos iniciales de configuración
@@ -36,7 +37,7 @@ function AjustesTab() {
   // Al montar el componente, se obtienen los datos desde el backend
   useEffect(() => {
     // Realiza una petición GET con Axios para obtener los datos
-    axios.get("http://localhost:3001/localStorage") // Ajusta la URL según corresponda
+    axios.get(`${API_BASE_URL}/localStorage`) // Ajusta la URL según corresponda
       .then(response => {
         const jsonData = response.data;
         console.log("JSON recibido desde backend:", jsonData);
@@ -68,7 +69,7 @@ function AjustesTab() {
   // Función para guardar los datos en el backend
   const saveData = () => {
     // Realiza una petición POST con Axios para enviar los datos
-    axios.post("http://localhost:3001/localStorage", data, {
+    axios.post(`${API_BASE_URL}/localStorage`, data, {
       headers: { "Content-Type": "application/json" }
     })
       .then(response => {

--- a/src/pages/CierreCaja.jsx
+++ b/src/pages/CierreCaja.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Imprimir from "./imprimir";
 import { useTheme } from "@mui/material/styles";
+import { API_BASE_URL } from '../config';
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1126,7 +1127,7 @@ function CierreCaja() {
   const togglePanelCierre = async () => {
     const fechaStr = fecha.toLocaleDateString("es-CL");
     try {
-      const queryUrl = `http://localhost:3001/api/cierres/existe?fecha=${encodeURIComponent(
+      const queryUrl = `${API_BASE_URL}/api/cierres/existe?fecha=${encodeURIComponent(
         fechaStr
       )}&tienda=${encodeURIComponent(selectedTienda)}&usuario=${encodeURIComponent(
         selectedUsuario
@@ -1170,7 +1171,7 @@ function CierreCaja() {
     };
   
     try {
-      const response = await fetch("http://localhost:3001/api/cierres", {
+      const response = await fetch(`${API_BASE_URL}/api/cierres`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(exportData)
@@ -1283,7 +1284,7 @@ function CierreCaja() {
 //
 async function loadAjustesFromBackend() {
   try {
-    const response = await fetch("http://localhost:3001/localStorage");
+    const response = await fetch(`${API_BASE_URL}/localStorage`);
     if (!response.ok) {
       throw new Error(`HTTP error: ${response.status}`);
     }

--- a/src/pages/Diferencias.jsx
+++ b/src/pages/Diferencias.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import moment from 'moment';
+import { API_BASE_URL } from '../config';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
@@ -487,7 +488,7 @@ function ControlCajas() {
       if (tiendaSeleccionada) params.tienda = tiendaSeleccionada;
       if (usuarioSeleccionado) params.usuario = usuarioSeleccionado;
 
-      const response = await axios.get('http://localhost:3001/api/cierres-completo', { params });
+      const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`, { params });
       const cierresData = response.data.map((cierre) => {
         let mediosPago = [];
         try {
@@ -517,7 +518,7 @@ function ControlCajas() {
   useEffect(() => {
     async function loadConfig() {
       try {
-        const response = await axios.get('http://localhost:3001/localStorage');
+        const response = await axios.get(`${API_BASE_URL}/localStorage`);
         setMotivos(response.data.motivos_error_pago || []);
         setTiendas(response.data.tiendas || []);
         setMediosPagoColumns(response.data.medios_pago || []);

--- a/src/pages/Exportar.jsx
+++ b/src/pages/Exportar.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { API_BASE_URL } from '../config';
 import {
   Box,
   Card,
@@ -95,7 +96,7 @@ const ExportarPage = () => {
     try {
       setLoading(true);
       setError(null);
-      const response = await axios.get('http://localhost:3001/api/cierres-completo');
+      const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`);
       
       if (!response.data || response.data.length === 0) {
         setError('No se encontraron datos en la base de datos');

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 import {
   Box,
   Typography,
@@ -46,7 +47,7 @@ const HomePage = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get('http://localhost:3001/api/cierres-completo');
+        const response = await axios.get(`${API_BASE_URL}/api/cierres-completo`);
         const data = response.data;
         setCierres(data);
         procesarDatos(data);


### PR DESCRIPTION
## Summary
- centralize API base URL using new `src/config.js`
- use the constant across components
- document API URL customization in README

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea54a6a8832eb3dc6484adc3ba7c