### PR TITLE
Fix backend root route when frontend build missing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,7 @@ const db = new Database(dbPath);
 // Serve built frontend if available
 const clientBuildPath = path.join(__dirname, '..', 'dist');
 if (fs.existsSync(clientBuildPath)) {
-  app.use(express.static(clientBuildPath));
+  app.use(express.static(clientBuildPath, { fallthrough: true }));
 }
 
 app.use(express.json());


### PR DESCRIPTION
## Summary
- ensure `express.static` doesn't swallow unknown routes

## Testing
- `npm install express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841efab52a4832e8b078b0c58f65b53